### PR TITLE
xmame fixes

### DIFF
--- a/games-emulation/xmame/files/fix-zn1-looping-sound.patch
+++ b/games-emulation/xmame/files/fix-zn1-looping-sound.patch
@@ -1,0 +1,81 @@
+diff --git a/src/sound/psx.c b/src/sound/psx.c
+index aa887e2..9c86ace 100644
+--- a/src/sound/psx.c
++++ b/src/sound/psx.c
+@@ -63,6 +63,18 @@ struct psxinfo
+ 	UINT16 m_p_n_volumeright[ MAX_CHANNEL ];
+ 	UINT16 m_p_n_pitch[ MAX_CHANNEL ];
+ 	UINT16 m_p_n_address[ MAX_CHANNEL ];
++	UINT16 m_p_n_envelopestate[ MAX_CHANNEL ];
++
++	enum envstate {
++		e_attack = 0,
++		e_decay,
++		e_sustain,
++		e_sustainEnd,
++		e_release,
++		e_releaseend
++	}
++	m_envstate;
++
+ 	UINT16 m_p_n_attackdecaysustain[ MAX_CHANNEL ];
+ 	UINT16 m_p_n_sustainrelease[ MAX_CHANNEL ];
+ 	UINT16 m_p_n_adsrvolume[ MAX_CHANNEL ];
+@@ -139,8 +151,22 @@ static void PSXSPU_update(void *param, stream_sample_t **inputs, stream_sample_t
+ 
+ 	for( n_channel = 0; n_channel < MAX_CHANNEL; n_channel++ )
+ 	{
+-		voll = volume( chip->m_p_n_volumeleft[ n_channel ] );
+-		volr = volume( chip->m_p_n_volumeright[ n_channel ] );
++		/*
++		 * (backport of https://github.com/mamedev/mame/commit/e763f88ea4bcb3eea6fa7bdb38780ae8475e8e7f )
++		 * hack, if the envelope is in release state, silence it
++		 * - the envelopes aren't currently emulated!
++		 * - and this prevents audiable sounds looping forever
++		 */
++		if( chip->m_p_n_envelopestate[ n_channel ] == e_release )
++		{
++			voll = 0;
++			volr = 0;
++		}
++		else
++		{
++			voll = volume( chip->m_p_n_volumeleft[ n_channel ] );
++			volr = volume( chip->m_p_n_volumeright[ n_channel ] );
++		}
+ 
+ 		for( n_sample = 0; n_sample < length; n_sample++ )
+ 		{
+@@ -331,6 +357,7 @@ static void *psxspu_start(int sndindex, int clock, const void *config)
+ 	state_save_register_item_array( "psx", sndindex, chip->m_p_n_volumeright );
+ 	state_save_register_item_array( "psx", sndindex, chip->m_p_n_pitch );
+ 	state_save_register_item_array( "psx", sndindex, chip->m_p_n_address );
++	state_save_register_item_array( "psx", sndindex, chip->m_p_n_envelopestate );
+ 	state_save_register_item_array( "psx", sndindex, chip->m_p_n_attackdecaysustain );
+ 	state_save_register_item_array( "psx", sndindex, chip->m_p_n_sustainrelease );
+ 	state_save_register_item_array( "psx", sndindex, chip->m_p_n_adsrvolume );
+@@ -539,6 +566,7 @@ WRITE32_HANDLER( psx_spu_w )
+ 					chip->m_p_n_s1[ n_channel ] = 0;
+ 					chip->m_p_n_s2[ n_channel ] = 0;
+ 					chip->m_p_n_blockstatus[ n_channel ] = 1;
++					chip->m_p_n_envelopestate[ n_channel ] = e_attack;
+ 				}
+ 			}
+ 			break;
+@@ -546,6 +574,16 @@ WRITE32_HANDLER( psx_spu_w )
+ 			chip->m_n_voiceoff = 0;
+ 			COMBINE_DATA( &chip->m_n_voiceoff );
+ 			verboselog( 1, "psx_spu_w() voice off = %08x\n", chip->m_n_voiceoff );
++
++			for( n_channel = 0; n_channel < 32; n_channel++ )
++			{
++				if( ( chip->m_n_voiceoff & ( 1 << n_channel ) ) != 0 )
++				{
++					/* keyoff advances the envelope to release state */
++					if( chip->m_p_n_envelopestate[ n_channel ] < e_release )
++						chip->m_p_n_envelopestate[ n_channel ] = e_release;
++				}
++			}
+ 			break;
+ 		case SPU_REG( 0xd90 ):
+ 			COMBINE_DATA( &chip->m_n_modulationmode );

--- a/games-emulation/xmame/xmame-0.106-r1.ebuild
+++ b/games-emulation/xmame/xmame-0.106-r1.ebuild
@@ -43,6 +43,7 @@ DEPEND="${RDEPEND}
 #	icc? ( dev-lang/icc )
 
 S=${WORKDIR}/xmame-${PV}
+PATCHES=( "${FILESDIR}/fix-zn1-looping-sound.patch" )
 
 toggle_feature() {
 	if use $1 ; then
@@ -57,6 +58,8 @@ toggle_feature2() {
 }
 
 src_prepare() {
+	default
+
 	local mycpu
 
 	case ${ARCH} in

--- a/games-emulation/xmame/xmame-0.106-r1.ebuild
+++ b/games-emulation/xmame/xmame-0.106-r1.ebuild
@@ -9,7 +9,7 @@ TARGET="${PN}"
 
 DESCRIPTION="Multiple Arcade Machine Emulator for X11"
 HOMEPAGE="http://x.mame.net/"
-SRC_URI="http://x.mame.net/download/xmame-${PV}.tar.bz2"
+SRC_URI="http://gentoo.osuosl.org/distfiles/xmame-${PV}.tar.bz2"
 
 LICENSE="XMAME"
 SLOT="0"


### PR DESCRIPTION
some fixes for ```games-emulation/xmame```

* download url was broken, I replaced it
* added a fix for glitchy sound effects in the ZN-1, backported from later versions of mame

I realize xmame is obsolete, however there are still some people who have reasons to use it - for example, it has much lower input latency on Tetris The Grandmaster 1 and probably every other ZN-1 game.