### PR TITLE
app-text/stardict: fix enchant dependency

### DIFF
--- a/app-text/stardict/stardict-3.0.6-r4.ebuild
+++ b/app-text/stardict/stardict-3.0.6-r4.ebuild
@@ -36,7 +36,7 @@ COMMON_DEPEND="
 	x11-libs/libX11
 	x11-libs/pango
 	gucharmap? ( gnome-extra/gucharmap:0= )
-	spell? ( >=app-text/enchant-1.2:= )
+	spell? ( >=app-text/enchant-1.2:0= )
 	tools? (
 		dev-libs/libpcre:=
 		dev-libs/libxml2:=

--- a/app-text/stardict/stardict-4.0.0_pre20170304-r1.ebuild
+++ b/app-text/stardict/stardict-4.0.0_pre20170304-r1.ebuild
@@ -40,7 +40,7 @@ COMMON_DEPEND="
 	espeak? ( >=app-accessibility/espeak-1.29 )
 	flite? ( app-accessibility/flite )
 	gucharmap? ( gnome-extra/gucharmap:2.90= )
-	spell? ( >=app-text/enchant-1.2:= )
+	spell? ( >=app-text/enchant-1.2:0= )
 	tools? (
 		dev-db/mysql-connector-c
 		dev-libs/expat


### PR DESCRIPTION
With enchant:2 the following error occurs during configuration phase:

```
checking for enchant >= 1.2.0... no
configure: error: Enchant library not found or too old. Use --disable-spell to build without spell plugin.
configure: error: ./configure failed for dict
```