### PR TITLE
Update media-gfx/ipe source location

### DIFF
--- a/media-gfx/ipe/ipe-7.2.26.ebuild
+++ b/media-gfx/ipe/ipe-7.2.26.ebuild
@@ -10,7 +10,7 @@ inherit desktop flag-o-matic lua-single toolchain-funcs
 
 DESCRIPTION="Drawing editor for creating figures in PDF or PS formats"
 HOMEPAGE="http://ipe.otfried.org/"
-SRC_URI="https://github.com/otfried/ipe/releases/download/v${PV}/${PN}-${PV}-src.tar.gz"
+SRC_URI="https://github.com/otfried/old-ipe-releases/releases/download/v${PV}/${PN}-${PV}-src.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"


### PR DESCRIPTION
All releases of media-gfx/ipe <= 7.2.26 have been moved to a new repository: https://github.com/otfried/old-ipe-releases/. The usual repository https://github.com/otfried/ipe/ only contains versions >= 7.2.27, which depend on QT6.